### PR TITLE
Reject the promise if there is an HTTP (or DNS) error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -32,7 +32,7 @@ Client.prototype.get = function(path, options) {
         try {
             this.client.get(this.baseUrl + path + query, function(data, response){
                 resolve(data);
-            });
+            }).on('error',reject);
         }
         catch(err) {
             reject(err);
@@ -48,7 +48,7 @@ Client.prototype.put = function(path, data, body) {
     return new Promise(function(resolve, reject) {
         this.client.put(this.baseUrl + path, args, function(data, response){
             resolve(data);
-        })
+        }).on('error', reject);
     }.bind(this));
 };
 


### PR DESCRIPTION
node-rest-client requires you to register an error listener to catch certain types of errors (such as DNS resolution failure). In order to maintain the promise API (which is great, thank you!) you'll need to register an error listener which can reject the promise.
